### PR TITLE
Allow for Stripe 3.x (#1)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "magento2-module",
   "require": {
     "magento/framework": "*",
-    "stripe/module-payments": "^2.0"
+    "stripe/module-payments": "^2.0|^3.0"
   },
   "authors": [{
     "name": "Eltrino LLC",


### PR DESCRIPTION
I've just bumped the `stripe/module-payments dependency` from `^2.0` to `^2.0|^3.0`

I've manually checked the used Stripe 3.x components and they seem to offer the same API.

Also tested locally and it seems to work.